### PR TITLE
Add Beacon API v4.0.0 blobs endpoint with versioned hash filtering

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -42,6 +42,17 @@
 			"name": "Attach Bun",
 			"url": "ws://localhost:6499/",
 			"stopOnEntry": false
+		},
+		{
+			"type": "go",
+			"name": "Debug API Service",
+			"request": "launch",
+			"mode": "auto",
+			"program": "${workspaceFolder}/api-service",
+			"env": {
+				"CONFIG_PATH": "${workspaceFolder}/api-service/config.yaml"
+			},
+			"cwd": "${workspaceFolder}/api-service"
 		}
 	]
 }

--- a/api-service/controllers/blobs.go
+++ b/api-service/controllers/blobs.go
@@ -88,7 +88,7 @@ func (bc *BlobsController) BlobsByBlockId(c *gin.Context) {
 //	@Summary	Get Blobs by block id (Beacon API v4.0.0)
 //	@Tags		blobs
 //	@Produce	json
-//	@Param		block_id			path		string		true	"Block identifier. Can be one of: 'head', 'genesis', 'finalized', slot number, or 0x-prefixed hex block root"
+//	@Param		block_id			path		string		true	"Block identifier. Can be one of: 'head', slot number, or 0x-prefixed hex block root"
 //	@Param		versioned_hashes	query		[]string	false	"Comma-separated list of 0x-prefixed 32-byte versioned hashes. Returns all blobs in the block if not specified."
 //	@Success	200		{object}	dto.BlobsResponse	"Successful response"
 //	@Failure	400		{object}	response.ApiErrorResponse	"invalid_slot or invalid_versioned_hash"

--- a/api-service/controllers/blobs.go
+++ b/api-service/controllers/blobs.go
@@ -5,6 +5,7 @@ import (
 	"blob-service/internal"
 	"blob-service/services"
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -77,4 +78,72 @@ func (bc *BlobsController) BlobsByBlockId(c *gin.Context) {
 	}
 
 	response.OkDataResponse(c, &response.ApiDataResponse{Data: resBlobs})
+}
+
+// BlobsByBlockIdV2 implements the Beacon API v4.0.0 endpoint that replaces
+// the deprecated /eth/v1/beacon/blob_sidecars/{block_id}. The response is a
+// flat list of blob byte strings, ordered by KZG commitment order in the
+// block, and filterable by versioned hash rather than blob index.
+//
+//	@Summary	Get Blobs by block id (Beacon API v4.0.0)
+//	@Tags		blobs
+//	@Produce	json
+//	@Param		block_id			path		string		true	"Block identifier. Can be one of: 'head', 'genesis', 'finalized', slot number, or 0x-prefixed hex block root"
+//	@Param		versioned_hashes	query		[]string	false	"Comma-separated list of 0x-prefixed 32-byte versioned hashes. Returns all blobs in the block if not specified."
+//	@Success	200		{object}	dto.BlobsResponse	"Successful response"
+//	@Failure	400		{object}	response.ApiErrorResponse	"invalid_slot or invalid_versioned_hash"
+//	@Failure	404		{object}	response.ApiErrorResponse	"slot_not_found"
+//	@Failure	500		{object}	response.ApiErrorResponse
+//	@Router		/eth/v1/beacon/blobs/{block_id} [get]
+func (bc *BlobsController) BlobsByBlockIdV2(c *gin.Context) {
+
+	blockId := c.Param("block_id")
+
+	hashFilter := map[[32]byte]struct{}{}
+	for _, str := range strings.Split(c.Query("versioned_hashes"), ",") {
+		if str == "" {
+			continue
+		}
+		h, err := internal.ParseVersionedHash(str)
+		if err != nil {
+			internal.WriteErrorResponse(c, internal.ErrInvalidVersionedHash)
+			return
+		}
+		hashFilter[h] = struct{}{}
+	}
+
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+	defer cancel()
+
+	slot, err := bc.blobsService.GetSlotByBlockId(ctx, blockId)
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			internal.WriteErrorResponse(c, internal.ErrSinkTimeout)
+			return
+		}
+		st, ok := status.FromError(err)
+		if ok && st.Code() == codes.NotFound {
+			internal.WriteErrorResponse(c, internal.ErrSlotNotFound)
+			return
+		}
+		internal.WriteErrorResponse(c, err)
+		return
+	}
+
+	data := []dto.HexBytes{}
+	for _, blob := range slot.Blobs {
+		if len(hashFilter) > 0 {
+			vh := internal.VersionedHashFromCommitment(blob.KzgCommitment)
+			if _, ok := hashFilter[vh]; !ok {
+				continue
+			}
+		}
+		data = append(data, dto.HexBytes(blob.Blob))
+	}
+
+	c.JSON(http.StatusOK, dto.BlobsResponse{
+		ExecutionOptimistic: false,
+		Finalized:           false,
+		Data:                data,
+	})
 }

--- a/api-service/dto/blobs.go
+++ b/api-service/dto/blobs.go
@@ -20,10 +20,14 @@ type Blob struct {
 // (Beacon API v4.0.0). It returns the raw blob data only — KZG commitments,
 // proofs, and inclusion proofs are omitted compared to the deprecated
 // blob_sidecars endpoint.
+//
+// The Data field marshals as an array of 0x-prefixed hex strings (see
+// HexBytes.MarshalJSON), so the swaggertype override below documents it
+// as such rather than as the raw []byte the Go type implies.
 type BlobsResponse struct {
 	ExecutionOptimistic bool       `json:"execution_optimistic"`
 	Finalized           bool       `json:"finalized"`
-	Data                []HexBytes `json:"data"`
+	Data                []HexBytes `json:"data" swaggertype:"array,string"`
 }
 
 type SignedBlockHeader struct {

--- a/api-service/dto/blobs.go
+++ b/api-service/dto/blobs.go
@@ -16,6 +16,16 @@ type Blob struct {
 	KzgCommitmentInclusionProof []HexBytes        `json:"kzg_commitment_inclusion_proof"`
 }
 
+// BlobsResponse is the response shape for GET /eth/v1/beacon/blobs/{block_id}
+// (Beacon API v4.0.0). It returns the raw blob data only — KZG commitments,
+// proofs, and inclusion proofs are omitted compared to the deprecated
+// blob_sidecars endpoint.
+type BlobsResponse struct {
+	ExecutionOptimistic bool       `json:"execution_optimistic"`
+	Finalized           bool       `json:"finalized"`
+	Data                []HexBytes `json:"data"`
+}
+
 type SignedBlockHeader struct {
 	Message   *Message `json:"message"`
 	Signature HexBytes `json:"signature"`

--- a/api-service/internal/errors.go
+++ b/api-service/internal/errors.go
@@ -12,17 +12,19 @@ import (
 )
 
 var (
-	ErrSinkTimeout  = errors.New("timeout when trying to reach the sink service")
-	ErrSlotNotFound = errors.New("slot not found")
-	ErrInvalidSlot  = errors.New("invalid slot")
-	ErrInvalidIndex = errors.New("invalid index")
+	ErrSinkTimeout          = errors.New("timeout when trying to reach the sink service")
+	ErrSlotNotFound         = errors.New("slot not found")
+	ErrInvalidSlot          = errors.New("invalid slot")
+	ErrInvalidIndex         = errors.New("invalid index")
+	ErrInvalidVersionedHash = errors.New("invalid versioned hash")
 )
 
 const (
-	NOT_FOUND_SLOT = "slot_not_found"
-	INVALID_SLOT   = "invalid_slot"
-	INVALID_INDEX  = "invalid_index"
-	SINK_TIMEOUT   = "sink_timeout"
+	NOT_FOUND_SLOT         = "slot_not_found"
+	INVALID_SLOT           = "invalid_slot"
+	INVALID_INDEX          = "invalid_index"
+	INVALID_VERSIONED_HASH = "invalid_versioned_hash"
+	SINK_TIMEOUT           = "sink_timeout"
 )
 
 func WriteErrorResponse(c *gin.Context, err error) {
@@ -40,6 +42,10 @@ func WriteErrorResponse(c *gin.Context, err error) {
 	}
 	if errors.Is(err, ErrInvalidIndex) {
 		helper.ReportPublicErrorAndAbort(c, response.NewApiErrorBadRequest(INVALID_INDEX), err)
+		return
+	}
+	if errors.Is(err, ErrInvalidVersionedHash) {
+		helper.ReportPublicErrorAndAbort(c, response.NewApiErrorBadRequest(INVALID_VERSIONED_HASH), err)
 		return
 	}
 

--- a/api-service/internal/utils.go
+++ b/api-service/internal/utils.go
@@ -1,5 +1,11 @@
 package internal
 
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
 func Contains[T comparable](slice []T, target T) bool {
 	for _, value := range slice {
 		if value == target {
@@ -7,4 +13,28 @@ func Contains[T comparable](slice []T, target T) bool {
 		}
 	}
 	return false
+}
+
+// VersionedHashFromCommitment computes the EIP-4844 versioned hash for a
+// KZG commitment: sha256(commitment) with the first byte replaced by the
+// blob-commitment version byte (0x01).
+func VersionedHashFromCommitment(commitment []byte) [32]byte {
+	h := sha256.Sum256(commitment)
+	h[0] = 0x01
+	return h
+}
+
+// ParseVersionedHash decodes a "0x"-prefixed 32-byte versioned hash string.
+// Returns ErrInvalidVersionedHash if the input is malformed.
+func ParseVersionedHash(s string) ([32]byte, error) {
+	var out [32]byte
+	if !strings.HasPrefix(s, "0x") && !strings.HasPrefix(s, "0X") {
+		return out, ErrInvalidVersionedHash
+	}
+	b, err := hex.DecodeString(s[2:])
+	if err != nil || len(b) != 32 {
+		return out, ErrInvalidVersionedHash
+	}
+	copy(out[:], b)
+	return out, nil
 }

--- a/api-service/internal/utils.go
+++ b/api-service/internal/utils.go
@@ -24,8 +24,10 @@ func VersionedHashFromCommitment(commitment []byte) [32]byte {
 	return h
 }
 
-// ParseVersionedHash decodes a "0x"-prefixed 32-byte versioned hash string.
-// Returns ErrInvalidVersionedHash if the input is malformed.
+// ParseVersionedHash decodes a "0x"-prefixed 32-byte versioned hash string
+// and rejects anything whose first byte is not the EIP-4844 blob-commitment
+// version byte (0x01). Without that check, a malformed hash silently matches
+// nothing instead of returning ErrInvalidVersionedHash.
 func ParseVersionedHash(s string) ([32]byte, error) {
 	var out [32]byte
 	if !strings.HasPrefix(s, "0x") && !strings.HasPrefix(s, "0X") {
@@ -33,6 +35,9 @@ func ParseVersionedHash(s string) ([32]byte, error) {
 	}
 	b, err := hex.DecodeString(s[2:])
 	if err != nil || len(b) != 32 {
+		return out, ErrInvalidVersionedHash
+	}
+	if b[0] != 0x01 {
 		return out, ErrInvalidVersionedHash
 	}
 	copy(out[:], b)

--- a/api-service/server/http_server.go
+++ b/api-service/server/http_server.go
@@ -69,6 +69,7 @@ func (s *HttpServer) Initialize() {
 
 	v1 := s.Router.Group("/eth/v1")
 	v1.GET("beacon/blob_sidecars/:block_id", blobsController.BlobsByBlockId)
+	v1.GET("beacon/blobs/:block_id", blobsController.BlobsByBlockIdV2)
 
 	s.Router.GET("/health", healthController.Health)
 

--- a/api-service/swagger/docs.go
+++ b/api-service/swagger/docs.go
@@ -281,10 +281,7 @@ const docTemplate = `{
                 "data": {
                     "type": "array",
                     "items": {
-                        "type": "array",
-                        "items": {
-                            "type": "integer"
-                        }
+                        "type": "string"
                     }
                 },
                 "execution_optimistic": {

--- a/api-service/swagger/docs.go
+++ b/api-service/swagger/docs.go
@@ -86,6 +86,62 @@ const docTemplate = `{
                 }
             }
         },
+        "/eth/v1/beacon/blobs/{block_id}": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "blobs"
+                ],
+                "summary": "Get Blobs by block id (Beacon API v4.0.0)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Block identifier. Can be one of: 'head', 'genesis', 'finalized', slot number, or 0x-prefixed hex block root",
+                        "name": "block_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv",
+                        "description": "Comma-separated list of 0x-prefixed 32-byte versioned hashes. Returns all blobs in the block if not specified.",
+                        "name": "versioned_hashes",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "schema": {
+                            "$ref": "#/definitions/dto.BlobsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "invalid_slot or invalid_versioned_hash",
+                        "schema": {
+                            "$ref": "#/definitions/response.ApiErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "slot_not_found",
+                        "schema": {
+                            "$ref": "#/definitions/response.ApiErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/response.ApiErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/health": {
             "get": {
                 "produces": [
@@ -216,6 +272,26 @@ const docTemplate = `{
                 },
                 "signed_block_header": {
                     "$ref": "#/definitions/dto.SignedBlockHeader"
+                }
+            }
+        },
+        "dto.BlobsResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "execution_optimistic": {
+                    "type": "boolean"
+                },
+                "finalized": {
+                    "type": "boolean"
                 }
             }
         },

--- a/api-service/swagger/swagger.json
+++ b/api-service/swagger/swagger.json
@@ -278,10 +278,7 @@
                 "data": {
                     "type": "array",
                     "items": {
-                        "type": "array",
-                        "items": {
-                            "type": "integer"
-                        }
+                        "type": "string"
                     }
                 },
                 "execution_optimistic": {

--- a/api-service/swagger/swagger.json
+++ b/api-service/swagger/swagger.json
@@ -83,6 +83,62 @@
                 }
             }
         },
+        "/eth/v1/beacon/blobs/{block_id}": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "blobs"
+                ],
+                "summary": "Get Blobs by block id (Beacon API v4.0.0)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Block identifier. Can be one of: 'head', 'genesis', 'finalized', slot number, or 0x-prefixed hex block root",
+                        "name": "block_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv",
+                        "description": "Comma-separated list of 0x-prefixed 32-byte versioned hashes. Returns all blobs in the block if not specified.",
+                        "name": "versioned_hashes",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "schema": {
+                            "$ref": "#/definitions/dto.BlobsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "invalid_slot or invalid_versioned_hash",
+                        "schema": {
+                            "$ref": "#/definitions/response.ApiErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "slot_not_found",
+                        "schema": {
+                            "$ref": "#/definitions/response.ApiErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/response.ApiErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/health": {
             "get": {
                 "produces": [
@@ -213,6 +269,26 @@
                 },
                 "signed_block_header": {
                     "$ref": "#/definitions/dto.SignedBlockHeader"
+                }
+            }
+        },
+        "dto.BlobsResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "execution_optimistic": {
+                    "type": "boolean"
+                },
+                "finalized": {
+                    "type": "boolean"
                 }
             }
         },

--- a/api-service/swagger/swagger.yaml
+++ b/api-service/swagger/swagger.yaml
@@ -48,9 +48,7 @@ definitions:
     properties:
       data:
         items:
-          items:
-            type: integer
-          type: array
+          type: string
         type: array
       execution_optimistic:
         type: boolean

--- a/api-service/swagger/swagger.yaml
+++ b/api-service/swagger/swagger.yaml
@@ -44,6 +44,19 @@ definitions:
       signed_block_header:
         $ref: '#/definitions/dto.SignedBlockHeader'
     type: object
+  dto.BlobsResponse:
+    properties:
+      data:
+        items:
+          items:
+            type: integer
+          type: array
+        type: array
+      execution_optimistic:
+        type: boolean
+      finalized:
+        type: boolean
+    type: object
   dto.Message:
     properties:
       body_root:
@@ -145,6 +158,45 @@ paths:
           schema:
             $ref: '#/definitions/response.ApiErrorResponse'
       summary: Get Blobs by block id
+      tags:
+      - blobs
+  /eth/v1/beacon/blobs/{block_id}:
+    get:
+      parameters:
+      - description: 'Block identifier. Can be one of: ''head'', ''genesis'', ''finalized'',
+          slot number, or 0x-prefixed hex block root'
+        in: path
+        name: block_id
+        required: true
+        type: string
+      - collectionFormat: csv
+        description: Comma-separated list of 0x-prefixed 32-byte versioned hashes.
+          Returns all blobs in the block if not specified.
+        in: query
+        items:
+          type: string
+        name: versioned_hashes
+        type: array
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successful response
+          schema:
+            $ref: '#/definitions/dto.BlobsResponse'
+        "400":
+          description: invalid_slot or invalid_versioned_hash
+          schema:
+            $ref: '#/definitions/response.ApiErrorResponse'
+        "404":
+          description: slot_not_found
+          schema:
+            $ref: '#/definitions/response.ApiErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/response.ApiErrorResponse'
+      summary: Get Blobs by block id (Beacon API v4.0.0)
       tags:
       - blobs
   /health:

--- a/api-service/test.http
+++ b/api-service/test.http
@@ -6,6 +6,14 @@ GET http://localhost:8080/eth/v1/beacon/blob_sidecars/head
 
 ###
 
+GET http://localhost:8080/eth/v1/beacon/blobs/7677000
+
+###
+
+GET http://localhost:8080/eth/v1/beacon/blobs/head
+
+###
+
 GET http://localhost:8080/health
 
 


### PR DESCRIPTION

This pull request introduces a new Beacon API v4.0.0 endpoint for retrieving blobs by block ID, along with supporting changes to error handling, utility functions, documentation, and tests. The new endpoint provides a simplified and standards-compliant way to fetch blob data, supporting filtering by versioned hash and returning only the raw blob bytes. The OpenAPI/Swagger documentation and error handling have been updated to reflect the new endpoint and its behaviors.

fixes #8 
