### PR TITLE
Add finality detection based on configurable slot lag

### DIFF
--- a/api-service/config.docker.yaml
+++ b/api-service/config.docker.yaml
@@ -6,6 +6,7 @@ application:
 
 chain:
   name: "Ethereum"      # The name of the chain for Swagger documentation
+  finality_lag: 64      # Slots behind head before a slot is reported finalized (>=2 epochs; Ethereum/Sepolia/Hoodi: 64, Gnosis: 32)
 
 sink:
   address: "host.docker.internal:8000" # The gRPC host of the sink server

--- a/api-service/config.docker.yaml
+++ b/api-service/config.docker.yaml
@@ -6,7 +6,7 @@ application:
 
 chain:
   name: "Ethereum"      # The name of the chain for Swagger documentation
-  finality_lag: 64      # Slots behind head before a slot is reported finalized (>=2 epochs; Ethereum/Sepolia/Hoodi: 64, Gnosis: 32)
+  # finality_lag: 64    # Optional. Defaults to 64 (Ethereum mainnet, 2 epochs). Gnosis: 32.
 
 sink:
   address: "host.docker.internal:8000" # The gRPC host of the sink server

--- a/api-service/config.example.yaml
+++ b/api-service/config.example.yaml
@@ -6,7 +6,7 @@ application:
 
 chain:
   name: "Ethereum"              # The name of the chain
-  finality_lag: 64              # Slots behind head before a slot is reported finalized. >=2 epochs (Ethereum/Sepolia/Hoodi: 64, Gnosis: 32). Pick higher for extra safety.
+  # finality_lag: 64            # Optional. Slots behind head before a slot is reported finalized. Defaults to 64 (Ethereum mainnet, 2 epochs). Gnosis: 32. Higher = more conservative.
 
 sink:
   address: "localhost:8000"     # The gRPC host of the sink server

--- a/api-service/config.example.yaml
+++ b/api-service/config.example.yaml
@@ -6,6 +6,7 @@ application:
 
 chain:
   name: "Ethereum"              # The name of the chain
+  finality_lag: 64              # Slots behind head before a slot is reported finalized. >=2 epochs (Ethereum/Sepolia/Hoodi: 64, Gnosis: 32). Pick higher for extra safety.
 
 sink:
   address: "localhost:8000"     # The gRPC host of the sink server

--- a/api-service/config/config.go
+++ b/api-service/config/config.go
@@ -7,11 +7,17 @@ import (
 type ChainConfig struct {
 	Name string `yaml:"name" json:"name" mapstructure:"name" validate:"required"`
 	// FinalityLag is the number of slots a block must be behind head before
-	// it is reported as `finalized` in beacon API responses. Pick a value
-	// at least 2 epochs (Ethereum/Sepolia/Hoodi: 64, Gnosis: 32); choose
-	// larger for extra safety margin during non-finality risk.
-	FinalityLag uint64 `yaml:"finality_lag" json:"finality_lag" mapstructure:"finality_lag" validate:"required"`
+	// it is reported as `finalized` in beacon API responses. When nil (key
+	// absent in config), DefaultFinalityLag is used. Set explicitly to 0
+	// to always report finalized=true (e.g. for chains where finality
+	// isn't tracked, or for testing). Typical values: Ethereum mainnet 64,
+	// Gnosis 32.
+	FinalityLag *uint64 `yaml:"finality_lag" json:"finality_lag" mapstructure:"finality_lag"`
 }
+
+// DefaultFinalityLag is 2 epochs on Ethereum mainnet — used when
+// chain.finality_lag is unset in the config.
+const DefaultFinalityLag uint64 = 64
 
 type SinkConfig struct {
 	Address string `yaml:"address" json:"address" mapstructure:"address" validate:"required"`

--- a/api-service/config/config.go
+++ b/api-service/config/config.go
@@ -6,6 +6,11 @@ import (
 
 type ChainConfig struct {
 	Name string `yaml:"name" json:"name" mapstructure:"name" validate:"required"`
+	// FinalityLag is the number of slots a block must be behind head before
+	// it is reported as `finalized` in beacon API responses. Pick a value
+	// at least 2 epochs (Ethereum/Sepolia/Hoodi: 64, Gnosis: 32); choose
+	// larger for extra safety margin during non-finality risk.
+	FinalityLag uint64 `yaml:"finality_lag" json:"finality_lag" mapstructure:"finality_lag" validate:"required"`
 }
 
 type SinkConfig struct {

--- a/api-service/controllers/blobs.go
+++ b/api-service/controllers/blobs.go
@@ -11,7 +11,9 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/pinax-network/golang-base/log"
 	"github.com/pinax-network/golang-base/response"
+	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -85,6 +87,13 @@ func (bc *BlobsController) BlobsByBlockId(c *gin.Context) {
 // flat list of blob byte strings, ordered by KZG commitment order in the
 // block, and filterable by versioned hash rather than blob index.
 //
+// The `finalized` flag is derived heuristically from the slot's distance
+// from head (≥ chain.finality_lag slots → finalized) rather than from the
+// consensus-layer finality checkpoint. This is accurate under normal
+// conditions but can over-report during extended non-finality periods.
+// `execution_optimistic` is always false — the backing sink only persists
+// fully-validated data.
+//
 //	@Summary	Get Blobs by block id (Beacon API v4.0.0)
 //	@Tags		blobs
 //	@Produce	json
@@ -141,9 +150,17 @@ func (bc *BlobsController) BlobsByBlockIdV2(c *gin.Context) {
 		data = append(data, dto.HexBytes(blob.Blob))
 	}
 
+	// Heuristic: slot is reported finalized once head is at least
+	// chain.finality_lag slots ahead of it. If the head lookup fails we
+	// fall back to a conservative finalized=false.
+	finalized, ferr := bc.blobsService.IsFinalized(ctx, slot.Slot)
+	if ferr != nil {
+		log.Warn("failed to determine finality, defaulting to finalized=false", zap.Error(ferr))
+	}
+
 	c.JSON(http.StatusOK, dto.BlobsResponse{
 		ExecutionOptimistic: false,
-		Finalized:           false,
+		Finalized:           finalized,
 		Data:                data,
 	})
 }

--- a/api-service/controllers/blobs.go
+++ b/api-service/controllers/blobs.go
@@ -11,9 +11,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/pinax-network/golang-base/log"
-	"github.com/pinax-network/golang-base/response"
-	"go.uber.org/zap"
+	_ "github.com/pinax-network/golang-base/response" // referenced by swagger annotations
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -33,7 +31,7 @@ func NewBlobsController(blobsService *services.BlobsService) *BlobsController {
 //	@Produce	json
 //	@Param		block_id	path		string		true	"Block identifier. Can be one of: 'head', slot number, hex encoded blockRoot with 0x prefix"
 //	@Param		indices		query	 	[]string 	false 	"Array of indices for blob sidecars to request for in the specified block. Returns all blob sidecars in the block if not specified."
-//	@Success	200		{object}	response.ApiDataResponse{data=[]dto.Blob} "Successful response"
+//	@Success	200		{object}	dto.BlobSidecarsResponse "Successful response"
 //	@Failure	400		{object}	response.ApiErrorResponse	"invalid_slot"	"Invalid block id"
 //	@Failure	404		{object}	response.ApiErrorResponse	"slot_not_found"	"Slot not found"
 //	@Failure	500		{object}	response.ApiErrorResponse
@@ -57,7 +55,7 @@ func (bc *BlobsController) BlobsByBlockId(c *gin.Context) {
 	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
 	defer cancel()
 
-	slot, err := bc.blobsService.GetSlotByBlockId(ctx, blockId)
+	slot, headSlot, err := bc.blobsService.GetSlotByBlockId(ctx, blockId)
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			internal.WriteErrorResponse(c, internal.ErrSinkTimeout)
@@ -79,7 +77,11 @@ func (bc *BlobsController) BlobsByBlockId(c *gin.Context) {
 		}
 	}
 
-	response.OkDataResponse(c, &response.ApiDataResponse{Data: resBlobs})
+	c.JSON(http.StatusOK, dto.BlobSidecarsResponse{
+		ExecutionOptimistic: false,
+		Finalized:           bc.blobsService.IsFinalized(slot.Slot, headSlot),
+		Data:                resBlobs,
+	})
 }
 
 // BlobsByBlockIdV2 implements the Beacon API v4.0.0 endpoint that replaces
@@ -124,7 +126,7 @@ func (bc *BlobsController) BlobsByBlockIdV2(c *gin.Context) {
 	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
 	defer cancel()
 
-	slot, err := bc.blobsService.GetSlotByBlockId(ctx, blockId)
+	slot, headSlot, err := bc.blobsService.GetSlotByBlockId(ctx, blockId)
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			internal.WriteErrorResponse(c, internal.ErrSinkTimeout)
@@ -150,17 +152,9 @@ func (bc *BlobsController) BlobsByBlockIdV2(c *gin.Context) {
 		data = append(data, dto.HexBytes(blob.Blob))
 	}
 
-	// Heuristic: slot is reported finalized once head is at least
-	// chain.finality_lag slots ahead of it. If the head lookup fails we
-	// fall back to a conservative finalized=false.
-	finalized, ferr := bc.blobsService.IsFinalized(ctx, slot.Slot)
-	if ferr != nil {
-		log.Warn("failed to determine finality, defaulting to finalized=false", zap.Error(ferr))
-	}
-
 	c.JSON(http.StatusOK, dto.BlobsResponse{
 		ExecutionOptimistic: false,
-		Finalized:           finalized,
+		Finalized:           bc.blobsService.IsFinalized(slot.Slot, headSlot),
 		Data:                data,
 	})
 }

--- a/api-service/dto/blobs.go
+++ b/api-service/dto/blobs.go
@@ -30,6 +30,14 @@ type BlobsResponse struct {
 	Data                []HexBytes `json:"data" swaggertype:"array,string"`
 }
 
+// BlobSidecarsResponse is the response shape for the deprecated
+// GET /eth/v1/beacon/blob_sidecars/{block_id} endpoint.
+type BlobSidecarsResponse struct {
+	ExecutionOptimistic bool    `json:"execution_optimistic"`
+	Finalized           bool    `json:"finalized"`
+	Data                []*Blob `json:"data"`
+}
+
 type SignedBlockHeader struct {
 	Message   *Message `json:"message"`
 	Signature HexBytes `json:"signature"`

--- a/api-service/server/http_server.go
+++ b/api-service/server/http_server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"blob-service/config"
 	"blob-service/controllers"
 	"blob-service/services"
 	"blob-service/swagger"
@@ -63,7 +64,11 @@ func (s *HttpServer) Initialize() {
 	s.Router.NoRoute(NoRoute)
 	s.Router.NoMethod(NoMethod)
 
-	blobsService := services.NewBlobsService(s.App.SinkClient, s.App.Config.Chain.FinalityLag)
+	finalityLag := config.DefaultFinalityLag
+	if s.App.Config.Chain.FinalityLag != nil {
+		finalityLag = *s.App.Config.Chain.FinalityLag
+	}
+	blobsService := services.NewBlobsService(s.App.SinkClient, finalityLag)
 	blobsController := controllers.NewBlobsController(blobsService)
 	healthController := controllers.NewHealthController(blobsService)
 

--- a/api-service/server/http_server.go
+++ b/api-service/server/http_server.go
@@ -63,7 +63,7 @@ func (s *HttpServer) Initialize() {
 	s.Router.NoRoute(NoRoute)
 	s.Router.NoMethod(NoMethod)
 
-	blobsService := services.NewBlobsService(s.App.SinkClient)
+	blobsService := services.NewBlobsService(s.App.SinkClient, s.App.Config.Chain.FinalityLag)
 	blobsController := controllers.NewBlobsController(blobsService)
 	healthController := controllers.NewHealthController(blobsService)
 

--- a/api-service/services/blobs.go
+++ b/api-service/services/blobs.go
@@ -31,31 +31,29 @@ func (bs *BlobsService) GetHeadSlot(ctx context.Context) (uint64, error) {
 	return binary.BigEndian.Uint64(resp.GetValue()), nil
 }
 
-// IsFinalized returns true when the given slot is at least `finalityLag`
-// slots behind head. This is a heuristic, not a real consensus-layer
-// finality check — under normal conditions blocks finalize within 2 epochs,
-// but extended non-finality periods can produce false positives. On head
-// lookup error this returns (false, err) so callers can fall back to a
-// conservative finalized=false.
-func (bs *BlobsService) IsFinalized(ctx context.Context, slot uint64) (bool, error) {
-	head, err := bs.GetHeadSlot(ctx)
-	if err != nil {
-		return false, err
+// IsFinalized reports whether `slot` is at least `finalityLag` slots behind
+// `headSlot`. This is a heuristic, not a real consensus-layer finality check:
+// under normal conditions blocks finalize within 2 epochs, but extended
+// non-finality periods can produce false positives. When finalityLag is 0
+// finality tracking is disabled and every slot is reported as finalized.
+//
+// The caller is expected to fetch the head slot once per request (see
+// GetSlotByBlockId) and pass it in here, so finality determination is free
+// of additional RPCs.
+func (bs *BlobsService) IsFinalized(slot, headSlot uint64) bool {
+	if bs.finalityLag == 0 {
+		return true
 	}
-	return head >= slot+bs.finalityLag, nil
+	return headSlot >= slot+bs.finalityLag
 }
 
-func (bc *BlobsService) GetSlotNumber(ctx context.Context, block_id string) (uint64, error) {
+func (bs *BlobsService) GetSlotNumber(ctx context.Context, block_id string) (uint64, error) {
 	if block_id == "head" {
-		resp, err := bc.sinkClient.Get(ctx, &pbkv.GetRequest{Key: "head"})
-		if err != nil {
-			return 0, err
-		}
-		return binary.BigEndian.Uint64(resp.GetValue()), nil
+		return bs.GetHeadSlot(ctx)
 	}
 
 	if len(block_id) > 2 && block_id[:2] == "0x" {
-		resp, err := bc.sinkClient.Get(ctx, &pbkv.GetRequest{Key: "block_root:" + block_id})
+		resp, err := bs.sinkClient.Get(ctx, &pbkv.GetRequest{Key: "block_root:" + block_id})
 		if err != nil {
 			return 0, err
 		}
@@ -70,23 +68,35 @@ func (bc *BlobsService) GetSlotNumber(ctx context.Context, block_id string) (uin
 	return slot, nil
 }
 
-func (bs *BlobsService) GetSlotByBlockId(ctx context.Context, blockId string) (*pbbl.Slot, error) {
+// GetSlotByBlockId fetches the head slot once, uses it to resolve
+// blockId == "head", and returns it alongside the requested slot so callers
+// can compute finality without a second RPC.
+func (bs *BlobsService) GetSlotByBlockId(ctx context.Context, blockId string) (*pbbl.Slot, uint64, error) {
 
-	slotNum, err := bs.GetSlotNumber(ctx, blockId)
+	headSlot, err := bs.GetHeadSlot(ctx)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
+	}
+
+	var slotNum uint64
+	if blockId == "head" {
+		slotNum = headSlot
+	} else {
+		slotNum, err = bs.GetSlotNumber(ctx, blockId)
+		if err != nil {
+			return nil, 0, err
+		}
 	}
 
 	resp, err := bs.sinkClient.Get(ctx, &pbkv.GetRequest{Key: fmt.Sprintf("slot:%d", slotNum)})
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	slot := &pbbl.Slot{}
-	err = proto.Unmarshal(resp.GetValue(), slot)
-	if err != nil {
-		return nil, err
+	if err := proto.Unmarshal(resp.GetValue(), slot); err != nil {
+		return nil, 0, err
 	}
 
-	return slot, nil
+	return slot, headSlot, nil
 }

--- a/api-service/services/blobs.go
+++ b/api-service/services/blobs.go
@@ -14,11 +14,35 @@ import (
 )
 
 type BlobsService struct {
-	sinkClient pbkv.KvClient
+	sinkClient  pbkv.KvClient
+	finalityLag uint64
 }
 
-func NewBlobsService(sinkClient pbkv.KvClient) *BlobsService {
-	return &BlobsService{sinkClient: sinkClient}
+func NewBlobsService(sinkClient pbkv.KvClient, finalityLag uint64) *BlobsService {
+	return &BlobsService{sinkClient: sinkClient, finalityLag: finalityLag}
+}
+
+// GetHeadSlot returns the current head slot from the sink.
+func (bs *BlobsService) GetHeadSlot(ctx context.Context) (uint64, error) {
+	resp, err := bs.sinkClient.Get(ctx, &pbkv.GetRequest{Key: "head"})
+	if err != nil {
+		return 0, err
+	}
+	return binary.BigEndian.Uint64(resp.GetValue()), nil
+}
+
+// IsFinalized returns true when the given slot is at least `finalityLag`
+// slots behind head. This is a heuristic, not a real consensus-layer
+// finality check — under normal conditions blocks finalize within 2 epochs,
+// but extended non-finality periods can produce false positives. On head
+// lookup error this returns (false, err) so callers can fall back to a
+// conservative finalized=false.
+func (bs *BlobsService) IsFinalized(ctx context.Context, slot uint64) (bool, error) {
+	head, err := bs.GetHeadSlot(ctx)
+	if err != nil {
+		return false, err
+	}
+	return head >= slot+bs.finalityLag, nil
 }
 
 func (bc *BlobsService) GetSlotNumber(ctx context.Context, block_id string) (uint64, error) {

--- a/api-service/swagger/docs.go
+++ b/api-service/swagger/docs.go
@@ -98,7 +98,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Block identifier. Can be one of: 'head', 'genesis', 'finalized', slot number, or 0x-prefixed hex block root",
+                        "description": "Block identifier. Can be one of: 'head', slot number, or 0x-prefixed hex block root",
                         "name": "block_id",
                         "in": "path",
                         "required": true

--- a/api-service/swagger/docs.go
+++ b/api-service/swagger/docs.go
@@ -47,22 +47,7 @@ const docTemplate = `{
                     "200": {
                         "description": "Successful response",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.ApiDataResponse"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "array",
-                                            "items": {
-                                                "$ref": "#/definitions/dto.Blob"
-                                            }
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/dto.BlobSidecarsResponse"
                         }
                     },
                     "400": {
@@ -272,6 +257,23 @@ const docTemplate = `{
                 },
                 "signed_block_header": {
                     "$ref": "#/definitions/dto.SignedBlockHeader"
+                }
+            }
+        },
+        "dto.BlobSidecarsResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/dto.Blob"
+                    }
+                },
+                "execution_optimistic": {
+                    "type": "boolean"
+                },
+                "finalized": {
+                    "type": "boolean"
                 }
             }
         },

--- a/api-service/swagger/swagger.json
+++ b/api-service/swagger/swagger.json
@@ -44,22 +44,7 @@
                     "200": {
                         "description": "Successful response",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.ApiDataResponse"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "array",
-                                            "items": {
-                                                "$ref": "#/definitions/dto.Blob"
-                                            }
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/dto.BlobSidecarsResponse"
                         }
                     },
                     "400": {
@@ -269,6 +254,23 @@
                 },
                 "signed_block_header": {
                     "$ref": "#/definitions/dto.SignedBlockHeader"
+                }
+            }
+        },
+        "dto.BlobSidecarsResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/dto.Blob"
+                    }
+                },
+                "execution_optimistic": {
+                    "type": "boolean"
+                },
+                "finalized": {
+                    "type": "boolean"
                 }
             }
         },

--- a/api-service/swagger/swagger.json
+++ b/api-service/swagger/swagger.json
@@ -95,7 +95,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Block identifier. Can be one of: 'head', 'genesis', 'finalized', slot number, or 0x-prefixed hex block root",
+                        "description": "Block identifier. Can be one of: 'head', slot number, or 0x-prefixed hex block root",
                         "name": "block_id",
                         "in": "path",
                         "required": true

--- a/api-service/swagger/swagger.yaml
+++ b/api-service/swagger/swagger.yaml
@@ -44,6 +44,17 @@ definitions:
       signed_block_header:
         $ref: '#/definitions/dto.SignedBlockHeader'
     type: object
+  dto.BlobSidecarsResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/dto.Blob'
+        type: array
+      execution_optimistic:
+        type: boolean
+      finalized:
+        type: boolean
+    type: object
   dto.BlobsResponse:
     properties:
       data:
@@ -135,14 +146,7 @@ paths:
         "200":
           description: Successful response
           schema:
-            allOf:
-            - $ref: '#/definitions/response.ApiDataResponse'
-            - properties:
-                data:
-                  items:
-                    $ref: '#/definitions/dto.Blob'
-                  type: array
-              type: object
+            $ref: '#/definitions/dto.BlobSidecarsResponse'
         "400":
           description: "invalid_slot\"\t\"Invalid block id"
           schema:

--- a/api-service/swagger/swagger.yaml
+++ b/api-service/swagger/swagger.yaml
@@ -161,8 +161,8 @@ paths:
   /eth/v1/beacon/blobs/{block_id}:
     get:
       parameters:
-      - description: 'Block identifier. Can be one of: ''head'', ''genesis'', ''finalized'',
-          slot number, or 0x-prefixed hex block root'
+      - description: 'Block identifier. Can be one of: ''head'', slot number, or 0x-prefixed
+          hex block root'
         in: path
         name: block_id
         required: true


### PR DESCRIPTION
This pull request introduces a heuristic-based approach for reporting block finality in the Beacon API, making finality determination configurable and more robust under normal network conditions. The main changes include adding a `finality_lag` configuration, updating how finality is determined and reported in the API, and clarifying related documentation.
