### PR TITLE
Improve query array parsing and add tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,11 +1,9 @@
-# Workflow to build the application and run endpoint tests
+# Workflow to build the application and run unit tests on every push and PR.
 name: Build & Tests
 
 on:
   push:
-    branches: [ develop*, main ]
   pull_request:
-    branches: [ develop*, main ]
 
 jobs:
 
@@ -33,6 +31,9 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
-        run: |
-          cd api-service
-          task build
+        working-directory: api-service
+        run: task build
+
+      - name: Test
+        working-directory: api-service
+        run: task test

--- a/api-service/Taskfile.yaml
+++ b/api-service/Taskfile.yaml
@@ -122,6 +122,11 @@ tasks:
           then exit 1;
         fi
 
+  test:
+    desc: "Runs the Go test suite"
+    cmds:
+      - go test ./...
+
   install:deps:
     desc: "Install Go dependencies such as swaggo to generate docs. The task gets the appropriate version from the go.mod file"
     cmds:

--- a/api-service/controllers/blobs.go
+++ b/api-service/controllers/blobs.go
@@ -30,7 +30,7 @@ func NewBlobsController(blobsService *services.BlobsService) *BlobsController {
 //	@Tags		blobs
 //	@Produce	json
 //	@Param		block_id	path		string		true	"Block identifier. Can be one of: 'head', slot number, hex encoded blockRoot with 0x prefix"
-//	@Param		indices		query	 	[]string 	false 	"Blob sidecar indices to return. Accepts repeated keys (?indices=0&indices=1) or comma-separated (?indices=0,1). Returns all if omitted."
+//	@Param		indices		query	 	[]string 	false 	"Blob sidecar indices to return. Accepts repeated keys (?indices=0&indices=1) or comma-separated (?indices=0,1). Returns all if omitted." collectionFormat(multi)
 //	@Success	200		{object}	dto.BlobSidecarsResponse "Successful response"
 //	@Failure	400		{object}	response.ApiErrorResponse	"invalid_slot"	"Invalid block id"
 //	@Failure	404		{object}	response.ApiErrorResponse	"slot_not_found"	"Slot not found"
@@ -105,7 +105,7 @@ func (bc *BlobsController) BlobsByBlockId(c *gin.Context) {
 //	@Tags		blobs
 //	@Produce	json
 //	@Param		block_id			path		string		true	"Block identifier. Can be one of: 'head', slot number, or 0x-prefixed hex block root"
-//	@Param		versioned_hashes	query		[]string	false	"0x-prefixed 32-byte versioned hashes to filter by. Accepts repeated keys (?versioned_hashes=0x01..&versioned_hashes=0x01..) or comma-separated. Returns all blobs if omitted."
+//	@Param		versioned_hashes	query		[]string	false	"0x-prefixed 32-byte versioned hashes to filter by. Accepts repeated keys (?versioned_hashes=0x01..&versioned_hashes=0x01..) or comma-separated. Returns all blobs if omitted." collectionFormat(multi)
 //	@Success	200		{object}	dto.BlobsResponse	"Successful response"
 //	@Failure	400		{object}	response.ApiErrorResponse	"invalid_slot or invalid_versioned_hash"
 //	@Failure	404		{object}	response.ApiErrorResponse	"slot_not_found"

--- a/api-service/controllers/blobs.go
+++ b/api-service/controllers/blobs.go
@@ -30,7 +30,7 @@ func NewBlobsController(blobsService *services.BlobsService) *BlobsController {
 //	@Tags		blobs
 //	@Produce	json
 //	@Param		block_id	path		string		true	"Block identifier. Can be one of: 'head', slot number, hex encoded blockRoot with 0x prefix"
-//	@Param		indices		query	 	[]string 	false 	"Array of indices for blob sidecars to request for in the specified block. Returns all blob sidecars in the block if not specified."
+//	@Param		indices		query	 	[]string 	false 	"Blob sidecar indices to return. Accepts repeated keys (?indices=0&indices=1) or comma-separated (?indices=0,1). Returns all if omitted."
 //	@Success	200		{object}	dto.BlobSidecarsResponse "Successful response"
 //	@Failure	400		{object}	response.ApiErrorResponse	"invalid_slot"	"Invalid block id"
 //	@Failure	404		{object}	response.ApiErrorResponse	"slot_not_found"	"Slot not found"
@@ -40,16 +40,21 @@ func (bc *BlobsController) BlobsByBlockId(c *gin.Context) {
 
 	blockId := c.Param("block_id")
 	indices := []uint32{}
-	for _, str := range strings.Split(c.Query("indices"), ",") {
-		if str == "" {
-			continue
+	// Accept both comma-separated (?indices=1,2,3) and repeated-key
+	// (?indices=1&indices=2) styles. Lighthouse uses the repeated form;
+	// older clients of ours use the comma form.
+	for _, raw := range c.QueryArray("indices") {
+		for _, str := range strings.Split(raw, ",") {
+			if str == "" {
+				continue
+			}
+			i, err := strconv.ParseUint(str, 10, 32)
+			if err != nil {
+				internal.WriteErrorResponse(c, internal.ErrInvalidIndex)
+				return
+			}
+			indices = append(indices, uint32(i))
 		}
-		i, err := strconv.ParseUint(str, 10, 32)
-		if err != nil {
-			internal.WriteErrorResponse(c, internal.ErrInvalidIndex)
-			return
-		}
-		indices = append(indices, uint32(i))
 	}
 
 	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
@@ -100,7 +105,7 @@ func (bc *BlobsController) BlobsByBlockId(c *gin.Context) {
 //	@Tags		blobs
 //	@Produce	json
 //	@Param		block_id			path		string		true	"Block identifier. Can be one of: 'head', slot number, or 0x-prefixed hex block root"
-//	@Param		versioned_hashes	query		[]string	false	"Comma-separated list of 0x-prefixed 32-byte versioned hashes. Returns all blobs in the block if not specified."
+//	@Param		versioned_hashes	query		[]string	false	"0x-prefixed 32-byte versioned hashes to filter by. Accepts repeated keys (?versioned_hashes=0x01..&versioned_hashes=0x01..) or comma-separated. Returns all blobs if omitted."
 //	@Success	200		{object}	dto.BlobsResponse	"Successful response"
 //	@Failure	400		{object}	response.ApiErrorResponse	"invalid_slot or invalid_versioned_hash"
 //	@Failure	404		{object}	response.ApiErrorResponse	"slot_not_found"
@@ -111,16 +116,21 @@ func (bc *BlobsController) BlobsByBlockIdV2(c *gin.Context) {
 	blockId := c.Param("block_id")
 
 	hashFilter := map[[32]byte]struct{}{}
-	for _, str := range strings.Split(c.Query("versioned_hashes"), ",") {
-		if str == "" {
-			continue
+	// Accept both comma-separated (?versioned_hashes=0x01...,0x01...) and
+	// repeated-key (?versioned_hashes=0x01...&versioned_hashes=0x01...)
+	// styles. Lighthouse uses the repeated form.
+	for _, raw := range c.QueryArray("versioned_hashes") {
+		for _, str := range strings.Split(raw, ",") {
+			if str == "" {
+				continue
+			}
+			h, err := internal.ParseVersionedHash(str)
+			if err != nil {
+				internal.WriteErrorResponse(c, internal.ErrInvalidVersionedHash)
+				return
+			}
+			hashFilter[h] = struct{}{}
 		}
-		h, err := internal.ParseVersionedHash(str)
-		if err != nil {
-			internal.WriteErrorResponse(c, internal.ErrInvalidVersionedHash)
-			return
-		}
-		hashFilter[h] = struct{}{}
 	}
 
 	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)

--- a/api-service/controllers/blobs_test.go
+++ b/api-service/controllers/blobs_test.go
@@ -1,0 +1,220 @@
+package controllers
+
+import (
+	pbbl "blob-service/pb/pinax/ethereum/blobs/v1"
+	"blob-service/services"
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/pinax-network/golang-base/middleware"
+	pbkv "github.com/streamingfast/substreams-sink-kv/pb/substreams/sink/kv/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
+)
+
+// fakeKv duplicates the small KvClient stub from services tests so the
+// controllers package can be tested in isolation without exposing test-only
+// helpers from another package.
+type fakeKv struct {
+	pbkv.KvClient
+	values map[string][]byte
+}
+
+func newFakeKv() *fakeKv { return &fakeKv{values: map[string][]byte{}} }
+
+func (f *fakeKv) Get(ctx context.Context, in *pbkv.GetRequest, opts ...grpc.CallOption) (*pbkv.GetResponse, error) {
+	v, ok := f.values[in.Key]
+	if !ok {
+		return nil, fmt.Errorf("fakeKv: unexpected key %q", in.Key)
+	}
+	return &pbkv.GetResponse{Value: v}, nil
+}
+
+func u64Bytes(n uint64) []byte {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, n)
+	return b
+}
+
+// versionedHashHex returns the 0x-prefixed EIP-4844 versioned hash of a
+// commitment, derived independently of the production helper so the test
+// pins the contract rather than the implementation.
+func versionedHashHex(commitment []byte) string {
+	digest := sha256.Sum256(commitment)
+	digest[0] = 0x01
+	return "0x" + hex.EncodeToString(digest[:])
+}
+
+// setupRouter returns a gin engine with both blobs routes mounted and the
+// middleware needed to render structured error responses. Tests call it
+// once per case and exercise the handler via httptest.
+func setupRouter(t *testing.T, headSlot uint64, finalityLag uint64, blobs []*pbbl.Blob) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	kv := newFakeKv()
+	kv.values["head"] = u64Bytes(headSlot)
+	slotProto := &pbbl.Slot{Slot: headSlot, Blobs: blobs}
+	raw, err := proto.Marshal(slotProto)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kv.values[fmt.Sprintf("slot:%d", headSlot)] = raw
+
+	svc := services.NewBlobsService(kv, finalityLag)
+	bc := NewBlobsController(svc)
+
+	r := gin.New()
+	r.Use(middleware.Errors())
+	v1 := r.Group("/eth/v1")
+	v1.GET("beacon/blob_sidecars/:block_id", bc.BlobsByBlockId)
+	v1.GET("beacon/blobs/:block_id", bc.BlobsByBlockIdV2)
+	return r
+}
+
+func doGet(t *testing.T, r *gin.Engine, url string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestBlobsByBlockIdV2_ResponseShape(t *testing.T) {
+	r := setupRouter(t, 1000, 64, []*pbbl.Blob{
+		{Index: 0, Blob: []byte{0xaa}, KzgCommitment: []byte{0x01}},
+	})
+	w := doGet(t, r, "/eth/v1/beacon/blobs/head")
+	if w.Code != 200 {
+		t.Fatalf("status: got %d want 200, body=%s", w.Code, w.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"execution_optimistic", "finalized", "data"} {
+		if _, ok := body[key]; !ok {
+			t.Errorf("missing field %q in response: %s", key, w.Body.String())
+		}
+	}
+	// blob at "head" slot is at distance 0 from head; lag=64 → not finalized.
+	if body["finalized"].(bool) {
+		t.Errorf("expected finalized=false for head request with lag=64")
+	}
+	if body["execution_optimistic"].(bool) {
+		t.Errorf("expected execution_optimistic=false")
+	}
+}
+
+func TestBlobsByBlockIdV2_VersionedHashFilter_CommaStyle(t *testing.T) {
+	r := setupRouter(t, 1000, 64, []*pbbl.Blob{
+		{Index: 0, Blob: []byte{0xaa}, KzgCommitment: []byte{0x01}},
+		{Index: 1, Blob: []byte{0xbb}, KzgCommitment: []byte{0x02}},
+		{Index: 2, Blob: []byte{0xcc}, KzgCommitment: []byte{0x03}},
+	})
+	url := fmt.Sprintf("/eth/v1/beacon/blobs/head?versioned_hashes=%s,%s",
+		versionedHashHex([]byte{0x01}), versionedHashHex([]byte{0x03}))
+	w := doGet(t, r, url)
+	if w.Code != 200 {
+		t.Fatalf("status: got %d want 200, body=%s", w.Code, w.Body.String())
+	}
+	var body struct {
+		Data []string `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if len(body.Data) != 2 {
+		t.Fatalf("got %d blobs, want 2: %v", len(body.Data), body.Data)
+	}
+	if !strings.HasPrefix(body.Data[0], "0xaa") || !strings.HasPrefix(body.Data[1], "0xcc") {
+		t.Errorf("filter order/contents wrong: %v", body.Data)
+	}
+}
+
+func TestBlobsByBlockIdV2_VersionedHashFilter_RepeatedStyle(t *testing.T) {
+	r := setupRouter(t, 1000, 64, []*pbbl.Blob{
+		{Index: 0, Blob: []byte{0xaa}, KzgCommitment: []byte{0x01}},
+		{Index: 1, Blob: []byte{0xbb}, KzgCommitment: []byte{0x02}},
+	})
+	url := fmt.Sprintf("/eth/v1/beacon/blobs/head?versioned_hashes=%s&versioned_hashes=%s",
+		versionedHashHex([]byte{0x02}), versionedHashHex([]byte{0x99}))
+	w := doGet(t, r, url)
+	if w.Code != 200 {
+		t.Fatalf("status: got %d want 200, body=%s", w.Code, w.Body.String())
+	}
+	var body struct {
+		Data []string `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if len(body.Data) != 1 || !strings.HasPrefix(body.Data[0], "0xbb") {
+		t.Errorf("expected just 0xbb, got %v", body.Data)
+	}
+}
+
+func TestBlobsByBlockIdV2_InvalidVersionedHashReturns400(t *testing.T) {
+	r := setupRouter(t, 1000, 64, nil)
+	w := doGet(t, r, "/eth/v1/beacon/blobs/head?versioned_hashes=0xnothex")
+	if w.Code != 400 {
+		t.Errorf("status: got %d want 400, body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestBlobsByBlockId_IndicesFilterBothStyles(t *testing.T) {
+	makeRouter := func() *gin.Engine {
+		return setupRouter(t, 1000, 64, []*pbbl.Blob{
+			{Index: 0, Blob: []byte{0xaa}, KzgCommitment: []byte{0x01}},
+			{Index: 1, Blob: []byte{0xbb}, KzgCommitment: []byte{0x02}},
+			{Index: 2, Blob: []byte{0xcc}, KzgCommitment: []byte{0x03}},
+		})
+	}
+	dataCount := func(body []byte) int {
+		var resp struct {
+			Data []json.RawMessage `json:"data"`
+		}
+		if err := json.Unmarshal(body, &resp); err != nil {
+			t.Fatal(err)
+		}
+		return len(resp.Data)
+	}
+
+	cases := []struct {
+		name string
+		url  string
+		want int
+	}{
+		{"comma style", "/eth/v1/beacon/blob_sidecars/head?indices=0,2", 2},
+		{"repeated style", "/eth/v1/beacon/blob_sidecars/head?indices=0&indices=2", 2},
+		{"no filter returns all", "/eth/v1/beacon/blob_sidecars/head", 3},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := doGet(t, makeRouter(), tc.url)
+			if w.Code != 200 {
+				t.Fatalf("status: got %d want 200", w.Code)
+			}
+			if n := dataCount(w.Body.Bytes()); n != tc.want {
+				t.Errorf("got %d entries want %d", n, tc.want)
+			}
+		})
+	}
+}
+
+func TestBlobsByBlockId_InvalidIndexReturns400(t *testing.T) {
+	r := setupRouter(t, 1000, 64, nil)
+	w := doGet(t, r, "/eth/v1/beacon/blob_sidecars/head?indices=notanumber")
+	if w.Code != 400 {
+		t.Errorf("status: got %d want 400, body=%s", w.Code, w.Body.String())
+	}
+}

--- a/api-service/controllers/blobs_test.go
+++ b/api-service/controllers/blobs_test.go
@@ -107,10 +107,18 @@ func TestBlobsByBlockIdV2_ResponseShape(t *testing.T) {
 		}
 	}
 	// blob at "head" slot is at distance 0 from head; lag=64 → not finalized.
-	if body["finalized"].(bool) {
+	finalized, ok := body["finalized"].(bool)
+	if !ok {
+		t.Fatalf("finalized: not a bool, got %T (%v)", body["finalized"], body["finalized"])
+	}
+	if finalized {
 		t.Errorf("expected finalized=false for head request with lag=64")
 	}
-	if body["execution_optimistic"].(bool) {
+	optimistic, ok := body["execution_optimistic"].(bool)
+	if !ok {
+		t.Fatalf("execution_optimistic: not a bool, got %T (%v)", body["execution_optimistic"], body["execution_optimistic"])
+	}
+	if optimistic {
 		t.Errorf("expected execution_optimistic=false")
 	}
 }

--- a/api-service/dto/blobs_test.go
+++ b/api-service/dto/blobs_test.go
@@ -1,0 +1,145 @@
+package dto
+
+import (
+	pbbl "blob-service/pb/pinax/ethereum/blobs/v1"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestHexBytesMarshalJSON(t *testing.T) {
+	cases := []struct {
+		name string
+		in   HexBytes
+		want string
+	}{
+		{"nil", nil, `"0x"`},
+		{"empty", HexBytes{}, `"0x"`},
+		{"single byte", HexBytes{0xab}, `"0xab"`},
+		{"multi byte", HexBytes{0xde, 0xad, 0xbe, 0xef}, `"0xdeadbeef"`},
+		{"leading zero preserved", HexBytes{0x00, 0x01}, `"0x0001"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := json.Marshal(tc.in)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(b) != tc.want {
+				t.Errorf("got %s want %s", b, tc.want)
+			}
+		})
+	}
+}
+
+func TestStrU64MarshalJSON(t *testing.T) {
+	cases := []struct {
+		in   StrU64
+		want string
+	}{
+		{0, `"0"`},
+		{1, `"1"`},
+		{12345, `"12345"`},
+		{1<<64 - 1, `"18446744073709551615"`},
+	}
+	for _, tc := range cases {
+		b, err := json.Marshal(tc.in)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(b) != tc.want {
+			t.Errorf("%d: got %s want %s", tc.in, b, tc.want)
+		}
+	}
+}
+
+func TestNewBlobCopiesFields(t *testing.T) {
+	slot := &pbbl.Slot{
+		Slot:          1234,
+		ProposerIndex: 99,
+		ParentRoot:    []byte{0x11},
+		StateRoot:     []byte{0x22},
+		BodyRoot:      []byte{0x33},
+		Signature:     []byte{0x44},
+	}
+	blob := &pbbl.Blob{
+		Index:                       7,
+		Blob:                        []byte{0xaa, 0xbb},
+		KzgCommitment:               []byte{0xcc},
+		KzgProof:                    []byte{0xdd},
+		KzgCommitmentInclusionProof: [][]byte{{0x01}, {0x02}, {0x03}},
+	}
+	got := NewBlob(blob, slot)
+	if got.Index != 7 {
+		t.Errorf("Index: got %d want 7", got.Index)
+	}
+	if string(got.Blob) != "\xaa\xbb" {
+		t.Errorf("Blob bytes mismatch")
+	}
+	if got.SignedBlockHeader.Message.Slot != 1234 {
+		t.Errorf("Slot: got %d want 1234", got.SignedBlockHeader.Message.Slot)
+	}
+	if got.SignedBlockHeader.Message.ProposerIndex != 99 {
+		t.Errorf("ProposerIndex: got %d want 99", got.SignedBlockHeader.Message.ProposerIndex)
+	}
+	if len(got.KzgCommitmentInclusionProof) != 3 {
+		t.Errorf("KzgCommitmentInclusionProof: got %d entries want 3", len(got.KzgCommitmentInclusionProof))
+	}
+}
+
+func TestBlobsResponseJSONShape(t *testing.T) {
+	resp := BlobsResponse{
+		ExecutionOptimistic: false,
+		Finalized:           true,
+		Data:                []HexBytes{{0xab}, {0xcd, 0xef}},
+	}
+	b, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(b)
+	// Field presence and the hex-string encoding for HexBytes inside an array.
+	for _, want := range []string{
+		`"execution_optimistic":false`,
+		`"finalized":true`,
+		`"data":["0xab","0xcdef"]`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("missing %s in %s", want, s)
+		}
+	}
+}
+
+func TestBlobSidecarsResponseJSONShape(t *testing.T) {
+	resp := BlobSidecarsResponse{
+		ExecutionOptimistic: false,
+		Finalized:           true,
+		Data: []*Blob{{
+			Index:         5,
+			Blob:          HexBytes{0xab},
+			KzgCommitment: HexBytes{0xcd},
+			KzgProof:      HexBytes{0xef},
+			SignedBlockHeader: SignedBlockHeader{
+				Message:   &Message{Slot: 1, ProposerIndex: 2},
+				Signature: HexBytes{0x11},
+			},
+		}},
+	}
+	b, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(b)
+	for _, want := range []string{
+		`"execution_optimistic":false`,
+		`"finalized":true`,
+		`"index":"5"`,            // StrU64 → JSON string
+		`"slot":"1"`,             // nested in signed_block_header
+		`"proposer_index":"2"`,
+		`"blob":"0xab"`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("missing %s in %s", want, s)
+		}
+	}
+}

--- a/api-service/dto/blobs_test.go
+++ b/api-service/dto/blobs_test.go
@@ -133,8 +133,8 @@ func TestBlobSidecarsResponseJSONShape(t *testing.T) {
 	for _, want := range []string{
 		`"execution_optimistic":false`,
 		`"finalized":true`,
-		`"index":"5"`,            // StrU64 → JSON string
-		`"slot":"1"`,             // nested in signed_block_header
+		`"index":"5"`, // StrU64 → JSON string
+		`"slot":"1"`,  // nested in signed_block_header
 		`"proposer_index":"2"`,
 		`"blob":"0xab"`,
 	} {

--- a/api-service/internal/utils_test.go
+++ b/api-service/internal/utils_test.go
@@ -1,0 +1,88 @@
+package internal
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"testing"
+)
+
+func TestVersionedHashFromCommitment(t *testing.T) {
+	// Known fixture: versioned hash of the empty commitment is the SHA-256
+	// of the empty byte string with the first byte forced to 0x01.
+	got := VersionedHashFromCommitment(nil)
+
+	empty := sha256.Sum256(nil)
+	want := empty
+	want[0] = 0x01
+
+	if got != want {
+		t.Errorf("empty commitment: got %x want %x", got, want)
+	}
+	if got[0] != 0x01 {
+		t.Errorf("first byte must be 0x01, got 0x%02x", got[0])
+	}
+
+	// Determinism + dependence on input.
+	a := VersionedHashFromCommitment([]byte{1, 2, 3})
+	b := VersionedHashFromCommitment([]byte{1, 2, 3})
+	c := VersionedHashFromCommitment([]byte{1, 2, 4})
+	if a != b {
+		t.Error("same input produced different hashes")
+	}
+	if a == c {
+		t.Error("different inputs produced the same hash")
+	}
+}
+
+func TestParseVersionedHash(t *testing.T) {
+	valid := "0x01" + strings.Repeat("ab", 31)
+	tests := []struct {
+		name    string
+		in      string
+		wantErr bool
+	}{
+		{"valid", valid, false},
+		{"valid uppercase prefix", "0X01" + strings.Repeat("ab", 31), false},
+		{"no 0x prefix", strings.TrimPrefix(valid, "0x"), true},
+		{"bad hex", "0x01zz" + strings.Repeat("ab", 30), true},
+		{"too short", "0x0100", true},
+		{"too long", valid + "ab", true},
+		{"wrong version byte 0x00", "0x00" + strings.Repeat("ab", 31), true},
+		{"wrong version byte 0x02", "0x02" + strings.Repeat("ab", 31), true},
+		{"empty", "", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseVersionedHash(tc.in)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err=%v wantErr=%v", err, tc.wantErr)
+			}
+			if err != nil {
+				return
+			}
+			// Round-trip: decoded bytes should match the hex input.
+			want, _ := hex.DecodeString(tc.in[2:])
+			for i := range got {
+				if got[i] != want[i] {
+					t.Errorf("byte %d: got 0x%02x want 0x%02x", i, got[i], want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestContains(t *testing.T) {
+	if !Contains([]int{1, 2, 3}, 2) {
+		t.Error("expected to find 2")
+	}
+	if Contains([]int{1, 2, 3}, 4) {
+		t.Error("did not expect to find 4")
+	}
+	if !Contains([]string{"a", "b"}, "b") {
+		t.Error("expected to find b")
+	}
+	if Contains([]int{}, 1) {
+		t.Error("empty slice should not contain anything")
+	}
+}

--- a/api-service/services/blobs_test.go
+++ b/api-service/services/blobs_test.go
@@ -1,0 +1,211 @@
+package services
+
+import (
+	"blob-service/internal"
+	pbbl "blob-service/pb/pinax/ethereum/blobs/v1"
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"testing"
+
+	pbkv "github.com/streamingfast/substreams-sink-kv/pb/substreams/sink/kv/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+)
+
+// fakeKv is a minimal in-memory KvClient implementation. Test cases preload
+// `values` (and optionally `notFound`); every Get is recorded in `calls` so
+// assertions can verify call counts/order.
+type fakeKv struct {
+	pbkv.KvClient
+	values   map[string][]byte
+	notFound map[string]bool
+	calls    []string
+}
+
+func newFakeKv() *fakeKv {
+	return &fakeKv{
+		values:   map[string][]byte{},
+		notFound: map[string]bool{},
+	}
+}
+
+func (f *fakeKv) Get(ctx context.Context, in *pbkv.GetRequest, opts ...grpc.CallOption) (*pbkv.GetResponse, error) {
+	f.calls = append(f.calls, in.Key)
+	if f.notFound[in.Key] {
+		return nil, status.Error(codes.NotFound, "not found")
+	}
+	v, ok := f.values[in.Key]
+	if !ok {
+		return nil, fmt.Errorf("fakeKv: unexpected key %q", in.Key)
+	}
+	return &pbkv.GetResponse{Value: v}, nil
+}
+
+func (f *fakeKv) callsFor(key string) int {
+	n := 0
+	for _, k := range f.calls {
+		if k == key {
+			n++
+		}
+	}
+	return n
+}
+
+func u64Bytes(n uint64) []byte {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, n)
+	return b
+}
+
+func marshalSlot(t *testing.T, s *pbbl.Slot) []byte {
+	t.Helper()
+	b, err := proto.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal slot: %v", err)
+	}
+	return b
+}
+
+func TestIsFinalized(t *testing.T) {
+	tests := []struct {
+		name        string
+		finalityLag uint64
+		slot, head  uint64
+		want        bool
+	}{
+		{"lag=0 disables tracking (slot==head)", 0, 1000, 1000, true},
+		{"lag=0 disables tracking (slot>head)", 0, 9999, 1000, true},
+		{"exactly at boundary", 64, 936, 1000, true},
+		{"one slot short of boundary", 64, 937, 1000, false},
+		{"far behind head", 64, 100, 1000, true},
+		{"slot equals head", 64, 1000, 1000, false},
+		{"slot ahead of head (no underflow)", 64, 2000, 1000, false},
+		{"large lag", 1024, 0, 1024, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			bs := NewBlobsService(newFakeKv(), tc.finalityLag)
+			if got := bs.IsFinalized(tc.slot, tc.head); got != tc.want {
+				t.Errorf("slot=%d head=%d lag=%d: got=%v want=%v", tc.slot, tc.head, tc.finalityLag, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsFinalizedZeroLagDoesNoRPC(t *testing.T) {
+	kv := newFakeKv()
+	bs := NewBlobsService(kv, 0)
+	_ = bs.IsFinalized(1234, 0)
+	if len(kv.calls) != 0 {
+		t.Errorf("expected zero RPCs when finalityLag=0, got %v", kv.calls)
+	}
+}
+
+func TestGetSlotNumber(t *testing.T) {
+	kv := newFakeKv()
+	kv.values["head"] = u64Bytes(7777)
+	kv.values["block_root:0xdead"] = u64Bytes(42)
+	bs := NewBlobsService(kv, 64)
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		in      string
+		want    uint64
+		wantErr error
+	}{
+		{"head", "head", 7777, nil},
+		{"block root", "0xdead", 42, nil},
+		{"numeric", "12345", 12345, nil},
+		{"invalid", "notaslot", 0, internal.ErrInvalidSlot},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := bs.GetSlotNumber(ctx, tc.in)
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("err=%v wantErr=%v", err, tc.wantErr)
+			}
+			if got != tc.want {
+				t.Errorf("got=%d want=%d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetSlotByBlockId_HeadFetchedOnceForHeadRequest(t *testing.T) {
+	kv := newFakeKv()
+	kv.values["head"] = u64Bytes(1000)
+	kv.values["slot:1000"] = marshalSlot(t, &pbbl.Slot{Slot: 1000})
+	bs := NewBlobsService(kv, 64)
+
+	slot, head, err := bs.GetSlotByBlockId(context.Background(), "head")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if head != 1000 || slot.Slot != 1000 {
+		t.Errorf("got head=%d slot=%d, want 1000/1000", head, slot.Slot)
+	}
+	if got := kv.callsFor("head"); got != 1 {
+		t.Errorf("expected head fetched exactly once, got %d (calls=%v)", got, kv.calls)
+	}
+	if got := kv.callsFor("slot:1000"); got != 1 {
+		t.Errorf("expected slot fetched once, got %d", got)
+	}
+}
+
+func TestGetSlotByBlockId_Numeric(t *testing.T) {
+	kv := newFakeKv()
+	kv.values["head"] = u64Bytes(1000)
+	kv.values["slot:500"] = marshalSlot(t, &pbbl.Slot{Slot: 500})
+	bs := NewBlobsService(kv, 64)
+
+	slot, head, err := bs.GetSlotByBlockId(context.Background(), "500")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if head != 1000 || slot.Slot != 500 {
+		t.Errorf("got head=%d slot=%d, want 1000/500", head, slot.Slot)
+	}
+	// head + slot, no block_root lookup
+	if got := len(kv.calls); got != 2 {
+		t.Errorf("expected 2 RPCs (head, slot), got %d: %v", got, kv.calls)
+	}
+}
+
+func TestGetSlotByBlockId_BlockRoot(t *testing.T) {
+	kv := newFakeKv()
+	kv.values["head"] = u64Bytes(1000)
+	kv.values["block_root:0xabc"] = u64Bytes(700)
+	kv.values["slot:700"] = marshalSlot(t, &pbbl.Slot{Slot: 700})
+	bs := NewBlobsService(kv, 64)
+
+	slot, head, err := bs.GetSlotByBlockId(context.Background(), "0xabc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if head != 1000 || slot.Slot != 700 {
+		t.Errorf("got head=%d slot=%d, want 1000/700", head, slot.Slot)
+	}
+	if got := len(kv.calls); got != 3 {
+		t.Errorf("expected 3 RPCs (head, block_root, slot), got %d: %v", got, kv.calls)
+	}
+}
+
+func TestGetSlotByBlockId_NotFound(t *testing.T) {
+	kv := newFakeKv()
+	kv.values["head"] = u64Bytes(1000)
+	kv.notFound["slot:1000"] = true
+	bs := NewBlobsService(kv, 64)
+
+	_, _, err := bs.GetSlotByBlockId(context.Background(), "head")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if st, ok := status.FromError(err); !ok || st.Code() != codes.NotFound {
+		t.Errorf("expected codes.NotFound, got %v", err)
+	}
+}

--- a/api-service/swagger/docs.go
+++ b/api-service/swagger/docs.go
@@ -38,7 +38,7 @@ const docTemplate = `{
                             "type": "string"
                         },
                         "collectionFormat": "csv",
-                        "description": "Array of indices for blob sidecars to request for in the specified block. Returns all blob sidecars in the block if not specified.",
+                        "description": "Blob sidecar indices to return. Accepts repeated keys (?indices=0\u0026indices=1) or comma-separated (?indices=0,1). Returns all if omitted.",
                         "name": "indices",
                         "in": "query"
                     }
@@ -94,7 +94,7 @@ const docTemplate = `{
                             "type": "string"
                         },
                         "collectionFormat": "csv",
-                        "description": "Comma-separated list of 0x-prefixed 32-byte versioned hashes. Returns all blobs in the block if not specified.",
+                        "description": "0x-prefixed 32-byte versioned hashes to filter by. Accepts repeated keys (?versioned_hashes=0x01..\u0026versioned_hashes=0x01..) or comma-separated. Returns all blobs if omitted.",
                         "name": "versioned_hashes",
                         "in": "query"
                     }

--- a/api-service/swagger/docs.go
+++ b/api-service/swagger/docs.go
@@ -37,7 +37,7 @@ const docTemplate = `{
                         "items": {
                             "type": "string"
                         },
-                        "collectionFormat": "csv",
+                        "collectionFormat": "multi",
                         "description": "Blob sidecar indices to return. Accepts repeated keys (?indices=0\u0026indices=1) or comma-separated (?indices=0,1). Returns all if omitted.",
                         "name": "indices",
                         "in": "query"
@@ -93,7 +93,7 @@ const docTemplate = `{
                         "items": {
                             "type": "string"
                         },
-                        "collectionFormat": "csv",
+                        "collectionFormat": "multi",
                         "description": "0x-prefixed 32-byte versioned hashes to filter by. Accepts repeated keys (?versioned_hashes=0x01..\u0026versioned_hashes=0x01..) or comma-separated. Returns all blobs if omitted.",
                         "name": "versioned_hashes",
                         "in": "query"

--- a/api-service/swagger/swagger.json
+++ b/api-service/swagger/swagger.json
@@ -34,7 +34,7 @@
                         "items": {
                             "type": "string"
                         },
-                        "collectionFormat": "csv",
+                        "collectionFormat": "multi",
                         "description": "Blob sidecar indices to return. Accepts repeated keys (?indices=0\u0026indices=1) or comma-separated (?indices=0,1). Returns all if omitted.",
                         "name": "indices",
                         "in": "query"
@@ -90,7 +90,7 @@
                         "items": {
                             "type": "string"
                         },
-                        "collectionFormat": "csv",
+                        "collectionFormat": "multi",
                         "description": "0x-prefixed 32-byte versioned hashes to filter by. Accepts repeated keys (?versioned_hashes=0x01..\u0026versioned_hashes=0x01..) or comma-separated. Returns all blobs if omitted.",
                         "name": "versioned_hashes",
                         "in": "query"

--- a/api-service/swagger/swagger.json
+++ b/api-service/swagger/swagger.json
@@ -35,7 +35,7 @@
                             "type": "string"
                         },
                         "collectionFormat": "csv",
-                        "description": "Array of indices for blob sidecars to request for in the specified block. Returns all blob sidecars in the block if not specified.",
+                        "description": "Blob sidecar indices to return. Accepts repeated keys (?indices=0\u0026indices=1) or comma-separated (?indices=0,1). Returns all if omitted.",
                         "name": "indices",
                         "in": "query"
                     }
@@ -91,7 +91,7 @@
                             "type": "string"
                         },
                         "collectionFormat": "csv",
-                        "description": "Comma-separated list of 0x-prefixed 32-byte versioned hashes. Returns all blobs in the block if not specified.",
+                        "description": "0x-prefixed 32-byte versioned hashes to filter by. Accepts repeated keys (?versioned_hashes=0x01..\u0026versioned_hashes=0x01..) or comma-separated. Returns all blobs if omitted.",
                         "name": "versioned_hashes",
                         "in": "query"
                     }

--- a/api-service/swagger/swagger.yaml
+++ b/api-service/swagger/swagger.yaml
@@ -132,7 +132,7 @@ paths:
         name: block_id
         required: true
         type: string
-      - collectionFormat: csv
+      - collectionFormat: multi
         description: Blob sidecar indices to return. Accepts repeated keys (?indices=0&indices=1)
           or comma-separated (?indices=0,1). Returns all if omitted.
         in: query
@@ -171,7 +171,7 @@ paths:
         name: block_id
         required: true
         type: string
-      - collectionFormat: csv
+      - collectionFormat: multi
         description: 0x-prefixed 32-byte versioned hashes to filter by. Accepts repeated
           keys (?versioned_hashes=0x01..&versioned_hashes=0x01..) or comma-separated.
           Returns all blobs if omitted.

--- a/api-service/swagger/swagger.yaml
+++ b/api-service/swagger/swagger.yaml
@@ -133,8 +133,8 @@ paths:
         required: true
         type: string
       - collectionFormat: csv
-        description: Array of indices for blob sidecars to request for in the specified
-          block. Returns all blob sidecars in the block if not specified.
+        description: Blob sidecar indices to return. Accepts repeated keys (?indices=0&indices=1)
+          or comma-separated (?indices=0,1). Returns all if omitted.
         in: query
         items:
           type: string
@@ -172,8 +172,9 @@ paths:
         required: true
         type: string
       - collectionFormat: csv
-        description: Comma-separated list of 0x-prefixed 32-byte versioned hashes.
-          Returns all blobs in the block if not specified.
+        description: 0x-prefixed 32-byte versioned hashes to filter by. Accepts repeated
+          keys (?versioned_hashes=0x01..&versioned_hashes=0x01..) or comma-separated.
+          Returns all blobs if omitted.
         in: query
         items:
           type: string


### PR DESCRIPTION
This pull request introduces comprehensive improvements to the blob API, focusing on enhanced query parameter handling, better documentation, and robust testing. The main highlights include support for both comma-separated and repeated-key query parameter styles in blob endpoints, improved OpenAPI documentation, and the addition of thorough unit tests for controllers, DTOs, and utility functions. The CI workflow is also updated to run unit tests on every push and PR.

**API improvements and documentation:**

* Updated the `/eth/v1/beacon/blob_sidecars/:block_id` and `/eth/v1/beacon/blobs/:block_id` endpoints to accept both comma-separated and repeated-key query parameters for `indices` and `versioned_hashes`, improving compatibility with different clients. [[1]](diffhunk://#diff-1230621b9b7d78edc98d227022821788b466a09b342f8e69a5085c772b328c1cL43-R47) [[2]](diffhunk://#diff-1230621b9b7d78edc98d227022821788b466a09b342f8e69a5085c772b328c1cR58) [[3]](diffhunk://#diff-1230621b9b7d78edc98d227022821788b466a09b342f8e69a5085c772b328c1cL114-R123) [[4]](diffhunk://#diff-1230621b9b7d78edc98d227022821788b466a09b342f8e69a5085c772b328c1cR134)
* Enhanced OpenAPI documentation for these endpoints to clearly describe the accepted query parameter formats. [[1]](diffhunk://#diff-1230621b9b7d78edc98d227022821788b466a09b342f8e69a5085c772b328c1cL33-R33) [[2]](diffhunk://#diff-1230621b9b7d78edc98d227022821788b466a09b342f8e69a5085c772b328c1cL103-R108)

**Testing and validation:**

* Added comprehensive unit tests for blob controllers, covering query parameter parsing, response shapes, and error handling.
* Introduced tests for DTOs to verify correct JSON marshaling and field copying.
* Added tests for utility functions, including versioned hash computation, parsing, and slice containment checks.

**CI/CD and workflow:**

* Modified the GitHub Actions workflow to run unit tests on every push and pull request, and to use the correct working directory for build and test steps. [[1]](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL1-L8) [[2]](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL36-R39)
* Added a `test` task to the `Taskfile.yaml` to run the Go test suite.